### PR TITLE
chore: update MCP name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mcp_server_figma"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "serde",
  "zed_extension_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp_server_figma"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Figma MCP Server Extension for Zed
+# Framelink Figma MCP Server Extension for Zed
 
 This extension integrates [Framelink Figma MCP Server](https://github.com/GLips/Figma-Context-MCP)
 as a context server for Zed's Assistant.

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "mcp-server-figma"
 name = "Framelink Figma MCP Server"
 description = "Model Context Protocol Server for Figma"
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Jeffrey Guenther <guenther.jeffrey@gmail.com>"]
 repository = "https://github.com/LoamStudios/zed-mcp-server-figma"

--- a/extension.toml
+++ b/extension.toml
@@ -1,5 +1,5 @@
 id = "mcp-server-figma"
-name = "FrameLink MCP Server"
+name = "Framelink Figma MCP Server"
 description = "Model Context Protocol Server for Figma"
 version = "0.0.1"
 schema_version = 1


### PR DESCRIPTION
Due to the way search works in the extension view, we want to ensure that the extension is findable with the term "figma".

Also, I ensure that the full name is used where possible. It's the Framelink Figma MCP Server.